### PR TITLE
Fixed spelling error on error message.

### DIFF
--- a/src/param.cc
+++ b/src/param.cc
@@ -87,7 +87,7 @@ void Param::parse(Model &model) {
     dout << "Indirectly called" << std::endl;
   } else {
     // Check that have have at least one argument
-    if (argc_ == 1) throw std::invalid_argument("To few command line arguments.");
+    if (argc_ == 1) throw std::invalid_argument("Too few command line arguments.");
 
     // Check if we need to print the help & version (only valid one argument commands)
     argv_i = argv_[1];
@@ -101,7 +101,7 @@ void Param::parse(Model &model) {
     }
 
     // Check that have have at least two arguments
-    if (argc_ == 2) throw std::invalid_argument("To few command line arguments.");
+    if (argc_ == 2) throw std::invalid_argument("Too few command line arguments.");
   }
 
   while( argc_i < argc_ ){


### PR DESCRIPTION
This PR fixes a minor spelling error in command line parsing code.
