### PR TITLE
-T ignores -p

### DIFF
--- a/src/summary_statistics/newick_tree.cc
+++ b/src/summary_statistics/newick_tree.cc
@@ -56,23 +56,24 @@ std::string NewickTree::generateTree(Node *node, const Forest &forest, const boo
   }
 
   // Generate a new tree
-  std::string tree;
-  if (node->in_sample()) tree = to_string(node->label());
+  std::stringstream tree;
+  tree.precision(std::cout.precision());
+  if (node->in_sample()) tree << to_string(node->label());
   else { 
     Node *left = node->getLocalChild1();
     Node *right = node->getLocalChild2();
 
-    tree = "(" + generateTree(left, forest, use_buffer) + ":" + 
-           to_string((node->height() - left->height()) * forest.model().scaling_factor()) +
-           "," + generateTree(right, forest, use_buffer) + ":" + 
-           to_string((node->height() - right->height()) * forest.model().scaling_factor()) + ")";
+    tree << "(" << generateTree(left, forest, use_buffer) << ":" <<
+           (node->height() - left->height()) * forest.model().scaling_factor() <<
+           "," << generateTree(right, forest, use_buffer) << ":" <<
+           (node->height() - right->height()) * forest.model().scaling_factor() << ")";
   }
 
   // And add to to the buffer
   if (use_buffer) {
-    NewickBuffer buf = {forest.current_base(), tree};
+    NewickBuffer buf = {forest.current_base(), tree.str()};
     buffer_[node] = buf; 
   }
 
-  return tree;
+  return tree.str();
 }


### PR DESCRIPTION
Branch lengths output in Newick trees are currently fixed at 6 significant digits, which is too small in some cases. This patch is a little hacky but seems to work.