### PR TITLE
Add option to print information about the model

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,14 +1,23 @@
 scrm Version History
 ========================
 
+scrm 1.5.0
+------------------------
+Released: Not yet
+
++ New feature: Added flag "--print-model" which prints a textual representation
+  of the demographic model for verification and debugging. 
+
+
+
 scrm 1.4.1
 ------------------------
 Released: 2015-04-04
 
 + Bug fix: Wrong population size where calculated when migration rates
   changes or population splits and merges occurred in an growth period (#56)
-+ Added an error message when a population size is set to 0 (#52)
 + Bug fix: When -es was used at time 0, _scrm_ ran into an endless loop (#53)
++ Improvement: Added an error message when a population size is set to 0 (#52)
 
 
 

--- a/src/model.cc
+++ b/src/model.cc
@@ -526,27 +526,30 @@ void Model::addSingleMigrationEvent(const double time, const size_t source_pop,
 std::ostream& operator<<(std::ostream& os, Model& model) {
   size_t n_pops = model.population_number();
   os << "---- Model: ------------------------" << std::endl;
-  os << "Sample size: " << model.sample_size() << std::endl;  
+  os << "Total Sample Size: " << model.sample_size() << std::endl;  
+  os << "N0 is assumed to be " << model.default_pop_size << std::endl; 
 
   model.resetSequencePosition();
   for (size_t idx = 0; idx < model.countChangePositions(); ++idx) {
-    os << std::endl << "At position " << model.getCurrentSequencePosition() << ":" << std::endl;  
-    os << " Mutation rate: " << model.mutation_rate() << std::endl;  
-    os << " Recombination rate: " << model.recombination_rate() << std::endl;  
+    os << std::endl << "At Position " << model.getCurrentSequencePosition() << ":" << std::endl;  
+    os << " Mutation Rate: " << model.mutation_rate() << std::endl;  
+    os << " Recombination Rate: " << model.recombination_rate() << std::endl;  
     model.increaseSequencePosition();
   }
   model.resetSequencePosition();
   
   model.resetTime();
   for (size_t idx = 0; idx < model.countChangeTimes(); ++idx) { 
-    os << std::endl << "At time " << model.getCurrentTime() << ":" << std::endl;  
+    os << std::endl << "At Time " << model.getCurrentTime() << ":" << std::endl;  
     
-    os << " Pop sizes:    ";
-    for (size_t pop = 0; pop < n_pops; ++pop) os << model.population_size(pop, model.getCurrentTime()) << "\t";
+    os << " Population Sizes: ";
+    for (size_t pop = 0; pop < n_pops; ++pop) 
+      os << std::setw(10) << std::right << model.population_size(pop, model.getCurrentTime());
     os << std::endl;
 
-    os << " Growth rates: ";
-    for (size_t pop = 0; pop < n_pops; ++pop) os << model.growth_rate(pop) << "\t";
+    os << " Growth Rates:     ";
+    for (size_t pop = 0; pop < n_pops; ++pop) 
+      os << std::setw(10) << std::right << model.growth_rate(pop);
     os << std::endl;
 
     os << " Migration Matrix: " << std::endl;

--- a/src/param.cc
+++ b/src/param.cc
@@ -397,6 +397,11 @@ void Param::parse(Model &model) {
       return;
     }
 
+    else if (argv_i == "-print-model" || argv_i == "--print-model") {
+      this->set_print_model(true);
+    } 
+
+
     // ------------------------------------------------------------------
     // Unsupported ms arguments
     // ------------------------------------------------------------------
@@ -507,12 +512,14 @@ void Param::printHelp(std::ostream& out) {
   out << "  -init <FILE>     Read genealogies at the beginning of the sequence." << std::endl;
 
   out << std::endl << "Other:" << std::endl;
-  out << "  -seed <SEED> [<SEED2> <SEED3>]   The random seed to use. Takes up three" << std::endl 
+  out << "  -seed <SEED> [<SEED2> <SEED3>]   The random seed to use. Takes up to three" << std::endl 
       << "                   integer numbers." << std::endl;
   out << "  -p <digits>      Specify the number of significant digits used in the output." << std::endl
       << "                   Defaults to 6." << std::endl;
   out << "  -v, --version    Prints the version of scrm." << std::endl;
   out << "  -h, --help       Prints this text." << std::endl;
+  out << "  -print-model,    " << std::endl
+      << "  --print-model    Prints information about the demographic model." << std::endl;
 
   out << std::endl << "Examples" << std::endl;
   out << "--------------------------------------------------------" << std::endl;

--- a/src/param.h
+++ b/src/param.h
@@ -68,6 +68,7 @@ class Param {
     directly_called_ = other.directly_called_;
     help_ = other.help_;
     version_ = other.version_;
+    print_model_ = other.print_model_;
     std::swap(argv_vec_, other.argv_vec_);
   }
 
@@ -81,6 +82,7 @@ class Param {
     directly_called_ = other.directly_called_;
     help_ = other.help_;
     version_ = other.version_;
+    print_model_ = other.print_model_;
     std::swap(argv_vec_, other.argv_vec_);
     return *this;
   }
@@ -91,6 +93,7 @@ class Param {
     this->set_help(false);
     this->set_version(false);
     this->set_precision(6);
+    this->set_print_model(false);
     argc_i = 0;
   }
 
@@ -99,13 +102,16 @@ class Param {
   bool version() const { return version_; }
   bool read_init_genealogy() const { return this->read_init_genealogy_; }
   size_t random_seed() const { return random_seed_; }
+  size_t precision() const { return precision_; }
+  bool seed_is_set() const { return this->seed_set_; }
+  bool print_model() const { return this->print_model_; }
+
+  void set_precision ( const size_t p ) { this->precision_ = p; }
   void set_random_seed(const size_t seed) { 
     this->random_seed_ = seed;
     this->seed_set_ = true; 
   }
-  size_t precision() const { return precision_; }
-  void set_precision ( const size_t p ) { this->precision_ = p; }
-  bool seed_is_set() const { return this->seed_set_; }
+  void set_print_model(const bool print_model) { print_model_ = print_model; }
 
   // Other methods
   void printHelp(std::ostream& stream);
@@ -156,6 +162,7 @@ class Param {
   bool help_;
   bool version_;
   bool read_init_genealogy_;
+  bool print_model_;
   std::vector<char*> argv_vec_;
 };
 #endif

--- a/src/scrm.cc
+++ b/src/scrm.cc
@@ -56,6 +56,10 @@ int main(int argc, char *argv[]){
     *output << user_para << std::endl;
     *output << rg.seed() << std::endl;
 
+    if (user_para.print_model()) {
+      *output << model << std::endl;
+    }
+
     // Create the forest
     Forest forest = Forest(&model, &rg);
 

--- a/tests/test_binaries.sh
+++ b/tests/test_binaries.sh
@@ -55,13 +55,13 @@ echo ""
 echo "Testing Migration"
  test_scrm 5 50 -r 5 100 -I 2 3 2 1.2 || exit 1
  test_scrm 10 1 -r 20 200 -I 5 2 2 2 2 2 0.75 -l 5 || exit 1
- test_scrm 10 1 -r 10 100 -I 2 7 3 0.5 -eM 0.3 1.1 || exit 1
+ test_scrm 10 1 -r 10 100 -I 2 7 3 0.5 -eM 0.3 1.1 --print-model || exit 1
  test_scrm 10 1 -r 10 100 -I 2 7 3 -m 1 2 0.3 -em 0.5 2 1 0.6 -eM 2.0 1 || exit 1
  test_scrm 20 100 -I 3 2 2 2 1.0 -eI 1.0 2 2 2 -eI 2.0 2 3 3 || exit 1
 echo ""
 
 echo "Testing Size Change"
-  test_scrm 10 2 -r 1 100 -I 3 3 3 4 0.5 -eN 0.1 0.05 -eN 0.2 0.5 || exit 1 
+  test_scrm 10 2 -r 1 100 -I 3 3 3 4 0.5 -eN 0.1 0.05 -eN 0.2 0.5 --print-model || exit 1 
   test_scrm 10 2 -r 10 100 -I 3 3 3 4 0.5 -eN 0.1 0.05 -eN 0.2 0.5 -l 10 || exit 1 
 echo ""
 

--- a/tests/unittests/test_param.cc
+++ b/tests/unittests/test_param.cc
@@ -545,6 +545,20 @@ class TestParam : public CppUnit::TestCase {
     CPPUNIT_ASSERT_EQUAL((size_t)1000, model.loci_number());
   }
 
+  void testPrintModel() {
+    Param pars;
+    pars = Param("scrm 4 7 -r 1 1001");
+    CPPUNIT_ASSERT_NO_THROW(pars.parse(model));
+    CPPUNIT_ASSERT_EQUAL(false, pars.print_model());
+
+    pars = Param("scrm 4 7 -r 1 1001 -print-model");
+    CPPUNIT_ASSERT_NO_THROW(pars.parse(model));
+    CPPUNIT_ASSERT_EQUAL(true, pars.print_model());
+
+    pars = Param("scrm 4 7 --print-model");
+    CPPUNIT_ASSERT_NO_THROW(pars.parse(model));
+    CPPUNIT_ASSERT_EQUAL(true, pars.print_model());
+  }
 };
 
 //Uncomment this to activate the test


### PR DESCRIPTION
`print-model` or `--print-model` now prints the debug information about the model. This may be useful for users to check their models and to verify that _scrm_ is doing the right thing.

Example:
```
scrm 10 1 -I 2 5 5 1 -G 2.7 --print-model -t 1
1958495831
---- Model: ------------------------
Total Sample Size: 10
N0 is assumed to be 10000

At Position 0:
 Mutation Rate: 2.5e-10
 Recombination Rate: 0

At Time 0:
 Population Sizes:      10000     10000
 Growth Rates:       6.75e-05  6.75e-05
 Migration Matrix: 
         0   2.5e-05
   2.5e-05         0
------------------------------------


//
segsites: 5
positions: 0.28992 0.577789 0.603842 0.745372 0.816716 
11001
00100
00110
11001
11001
11001
11001
11001
11001
11001
```