### PR TITLE
remove complete pruning completely

### DIFF
--- a/src/forest-debug.cc
+++ b/src/forest-debug.cc
@@ -496,12 +496,12 @@ std::vector<Node const*> Forest::determinePositions() const {
   }
 
   bool Forest::printNodes() const {
-    std::cout << std::setw(10) << std::right << "Node";
-    std::cout << std::setw(10) << std::right << "Height";
+    std::cout << std::setw(15) << std::right << "Node";
+    std::cout << std::setw(15) << std::right << "Height";
     std::cout << std::setw(6) << std::right << "label";
-    std::cout << std::setw(10) << std::right << "Parent";
-    std::cout << std::setw(10) << std::right << "1th_child";
-    std::cout << std::setw(10) << std::right << "2nd_child";
+    std::cout << std::setw(15) << std::right << "Parent";
+    std::cout << std::setw(15) << std::right << "1th_child";
+    std::cout << std::setw(15) << std::right << "2nd_child";
     std::cout << std::setw(6) << std::right << "local";
     std::cout << std::setw(6) << std::right << "pop";
     std::cout << std::setw(10) << std::right << "l_upd";
@@ -510,14 +510,14 @@ std::vector<Node const*> Forest::determinePositions() const {
     std::cout << std::endl;
 
     for(size_t i = 0; i < this->getNodes()->size(); ++i) {
-      std::cout << std::setw(10) << std::right << this->getNodes()->get(i);
-      std::cout << std::setw(10) << std::right << this->getNodes()->get(i)->height();
+      std::cout << std::setw(15) << std::right << this->getNodes()->get(i);
+      std::cout << std::setw(15) << std::right << this->getNodes()->get(i)->height();
       std::cout << std::setw(6) << std::right << this->getNodes()->get(i)->label();
       if (!getNodes()->get(i)->is_root()) 
-        std::cout << std::setw(10) << std::right << this->getNodes()->get(i)->parent();
-      else std::cout << std::setw(10) << std::right << 0;
-      std::cout << std::setw(10) << std::right << this->getNodes()->get(i)->first_child();
-      std::cout << std::setw(10) << std::right << this->getNodes()->get(i)->second_child();
+        std::cout << std::setw(15) << std::right << this->getNodes()->get(i)->parent();
+      else std::cout << std::setw(15) << std::right << 0;
+      std::cout << std::setw(15) << std::right << this->getNodes()->get(i)->first_child();
+      std::cout << std::setw(15) << std::right << this->getNodes()->get(i)->second_child();
       std::cout << std::setw(6) << std::right << this->getNodes()->get(i)->local();
       std::cout << std::setw(6) << std::right << this->getNodes()->get(i)->population();
       std::cout << std::setw(10) << std::right << this->getNodes()->get(i)->last_update();

--- a/src/forest.cc
+++ b/src/forest.cc
@@ -414,7 +414,6 @@ void Forest::sampleNextGenealogy() {
     return;
   }
 
-  dout << tmp_event_time_ << std::endl;
   assert( tmp_event_time_ >= 0 );
   this->contemporaries_.buffer(tmp_event_time_);
 
@@ -443,9 +442,6 @@ void Forest::sampleNextGenealogy() {
   assert( this->checkTree() );
   assert( this->printTree() );
   assert( this->printNodes() );
-
-  // Rarely prune all possible nodes 
-  if (segment_count_ % 100000 == 0 && model().exact_window_length() != -1) this->doCompletePruning();
 
   this->sampleNextBase();
   this->calcSegmentSumStats();
@@ -1204,14 +1200,6 @@ void Forest::printLocusSumStats(std::ostream &output) const {
   for (size_t i = 0; i < model().countSummaryStatistics(); ++i) {
     model().getSummaryStatistic(i)->printLocusOutput(output);
   }
-}
-
-void Forest::doCompletePruning() {
-  dout << "Pruning Tree:" << std::endl;
-  for (NodeIterator ni = nodes()->iterator(nodes()->first()->next()); ni.good(); ++ni) {
-    pruneNodeIfNeeded((*ni)->previous());
-  }
-  pruneNodeIfNeeded(nodes()->last());
 }
 
 void Forest::clear() {

--- a/src/forest.h
+++ b/src/forest.h
@@ -245,7 +245,6 @@ class Forest
   }
 
   bool pruneNodeIfNeeded(Node* node, const bool prune_orphans = true);
-  void doCompletePruning();
 
   // Calculation of Rates
   double calcCoalescenceRate(const size_t pop, const TimeInterval &ti) const;

--- a/src/node.cc
+++ b/src/node.cc
@@ -61,7 +61,13 @@ void Node::change_child(Node* from, Node* to) {
   }
   else if ( this->second_child() == from )
     this->set_second_child(to);
-  else throw std::invalid_argument("Can't find child node to replace");
+  else {
+    dout << "Error when changing child of " << this << " form "
+         << from << " to " << to << std::endl;
+    dout << "Children are " << this->first_child() << " and "
+         << this->second_child() << std::endl;
+    throw std::invalid_argument("Can't find child node to replace");
+  }
 }
 
 void Node::remove_child(Node* child) {

--- a/tools/try_seeds.sh
+++ b/tools/try_seeds.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+
+pars=$@
+[ $# == 0 ] && pars='5 10 -r 100 1000 -l 50'
+make -j2 scrm
+
+i=0
+while [ 1 ]; do
+  ((i++))
+  echo "Seed: $i"
+  ./scrm $pars -seed $i > /dev/null 
+  [ $? -eq 0 ] || { echo "Failed: ./scrm $pars -seed $i"; exit 1; }
+done


### PR DESCRIPTION
+ Bugfix: So far, scrm rarely did a complete pruning of the tree, additional to removing the nodes that the algorithm encounters. This is not really necessary or advantageous and caused a problem that made the program abort in some cases. The complete pruning step is now completely disabled (#70, #71).