### PR TITLE
Fix corrupt trees when the ostringstream is full

### DIFF
--- a/src/model.cc
+++ b/src/model.cc
@@ -23,33 +23,14 @@
 
 
 Model::Model() { 
-  this->init();
-}
-
-Model::Model(size_t sample_size) {
-  this->init();
-  this->addSampleSizes(0.0, std::vector<size_t>(1, sample_size));
-  this->resetTime();
-}
-
-void Model::init() {
   default_pop_size = 10000;
   default_loci_length = 100000;
   default_growth_rate = 0.0;
   default_mig_rate = 0.0;
   scaling_factor_ = 1.0 / (4 * default_pop_size);
 
-  sample_times_ = std::vector<double>();
-  sample_populations_ = std::vector<size_t>();
-
-  change_times_ = std::vector<double>();
-  pop_sizes_list_ = std::vector<std::vector<double> >();
-  growth_rates_list_ = std::vector<std::vector<double> >();
-  mig_rates_list_ = std::vector<std::vector<double> >();
-  total_mig_rates_list_ = std::vector<std::vector<double> >(); 
-  single_mig_probs_list_ = std::vector<std::vector<double> >();
-
   has_migration_ = false;
+  has_recombination_ = false;
 
   this->addChangeTime(0.0);
   this->addChangePosition(0.0);
@@ -72,6 +53,14 @@ void Model::init() {
   this->resetSequencePosition();
 }
 
+
+Model::Model(size_t sample_size) : Model() {
+  this->addSampleSizes(0.0, std::vector<size_t>(1, sample_size));
+  this->resetTime();
+}
+
+
+/*
 void Model::reset() {
   pop_sizes_list_.clear();
   growth_rates_list_.clear();
@@ -79,9 +68,8 @@ void Model::reset() {
   total_mig_rates_list_.clear();
   single_mig_probs_list_.clear();
   summary_statistics_.clear();
-
-  init();
 }
+*/
 
 /** 
  * Function to add a new change time to the model.
@@ -695,6 +683,7 @@ void Model::setRecombinationRate(double rate,
     rate /= loci_length()-1;
   }
 
+  if (rate > 0.0) has_recombination_ = true;
   recombination_rates_[addChangePosition(seq_position)] = rate; 
 }
 

--- a/src/model.h
+++ b/src/model.h
@@ -107,7 +107,7 @@ class Model
     * @return true if the model has recombination, false otherwise 
     */
    bool has_recombination() const { 
-     return has_recombination_t; 
+     return has_recombination_; 
    };
 
 

--- a/src/model.h
+++ b/src/model.h
@@ -66,7 +66,6 @@ class Model
    Model();
    Model(size_t sample_size);
 
-   void init();
    
    // Default values;
    double default_pop_size;
@@ -101,6 +100,16 @@ class Model
      if (idx == -1) return recombination_rates_.at(current_seq_idx_); 
      else return recombination_rates_.at(idx);
    }
+
+   /**
+    * @brief Returns if the model has recombination.
+    *
+    * @return true if the model has recombination, false otherwise 
+    */
+   bool has_recombination() const { 
+     return has_recombination_t; 
+   };
+
 
    /**
     * @brief Returns the length of all loci, in base pairs
@@ -375,7 +384,7 @@ class Model
    void finalize(); 
   
    void check();
-   void reset();
+   //void reset();
 
    size_t countSummaryStatistics() const {
      return summary_statistics_.size(); 
@@ -426,7 +435,6 @@ class Model
    }
 
    void updateTotalMigRates(const size_t position);
-   bool has_migration_;
    bool has_migration() { return has_migration_; };
 
   void fillVectorList(std::vector<std::vector<double> > &vector_list, const double default_value);
@@ -496,6 +504,9 @@ class Model
    bool has_window_seq_;
    bool has_window_rec_;
    bool has_appr_;
+
+   bool has_migration_;
+   bool has_recombination_;
 
    SeqScale seq_scale_;
 

--- a/src/param.cc
+++ b/src/param.cc
@@ -425,7 +425,9 @@ Model Param::parse() {
 
   // Add summary statistics in order of their output
   if (newick_trees) model.addSummaryStatistic(std::make_shared<NewickTree>(this->precision()));
-  if (orientedForest) model.addSummaryStatistic(std::make_shared<OrientedForest>(model.sample_size()));
+  if (orientedForest) {
+    model.addSummaryStatistic(std::make_shared<OrientedForest>(model.sample_size(), this->precision()));
+  }
   if (tmrca) model.addSummaryStatistic(std::make_shared<TMRCA>());
   if (seg_sites.get() != NULL) model.addSummaryStatistic(seg_sites);
   if (sfs) {

--- a/src/param.cc
+++ b/src/param.cc
@@ -424,7 +424,8 @@ Model Param::parse() {
   }
 
   // Add summary statistics in order of their output
-  if (newick_trees) model.addSummaryStatistic(std::make_shared<NewickTree>(this->precision()));
+  if (newick_trees) model.addSummaryStatistic(std::make_shared<NewickTree>(this->precision(), 
+                                                                           model.has_recombination()));
   if (orientedForest) {
     model.addSummaryStatistic(std::make_shared<OrientedForest>(model.sample_size(), this->precision()));
   }

--- a/src/summary_statistics/newick_tree.cc
+++ b/src/summary_statistics/newick_tree.cc
@@ -34,7 +34,7 @@ void NewickTree::calculate(const Forest &forest) {
 }
 
 void NewickTree::printLocusOutput(std::ostream &output) const {
-  output << output_buffer_.str();  
+  output << output_buffer_.rdbuf();  
 }
 
 /**

--- a/src/summary_statistics/newick_tree.cc
+++ b/src/summary_statistics/newick_tree.cc
@@ -22,19 +22,22 @@
 #include "newick_tree.h"
 
 void NewickTree::calculate(const Forest &forest) {
-  if (forest.model().recombination_rate() == 0.0) {
-    output_buffer_ << generateTree(forest.local_root(), forest) 
-                   << ";" << std::endl;  
-  } else {
-    if (forest.calcSegmentLength() == 0.0) return;
-    output_buffer_ << "[" << forest.calcSegmentLength() << "]" 
-                   << generateTree(forest.local_root(), forest)
-                   << ";" << std::endl;
-  }
+  if (forest.calcSegmentLength() == 0.0) return;
+  output_buffer_.push_back(generateTree(forest.local_root(), forest)); 
+  segment_length_.push_back(forest.calcSegmentLength());
 }
 
 void NewickTree::printLocusOutput(std::ostream &output) const {
-  output << output_buffer_.rdbuf();  
+  assert( output_buffer_.size() == segment_length_.size() );
+  if (!has_rec_) {
+    assert( output_buffer_.size() == 1 );
+    output << *(output_buffer_.begin()) << ";" << std::endl;
+  } else {
+    size_t i = 0;
+    for (auto tree : output_buffer_) {
+      output << "[" << segment_length_[i++] << "]" << tree << ";" << std::endl;
+    }
+  }
 }
 
 /**
@@ -58,6 +61,7 @@ std::string NewickTree::generateTree(Node *node, const Forest &forest, const boo
   // Generate a new tree
   std::stringstream tree;
   tree.precision(this->precision_);
+  tree.exceptions(std::ios::failbit); 
   if (node->in_sample()) tree << node->label();
   else { 
     Node *left = node->getLocalChild1();

--- a/src/summary_statistics/newick_tree.h
+++ b/src/summary_statistics/newick_tree.h
@@ -44,14 +44,11 @@ struct NewickBuffer {
 class NewickTree : public SummaryStatistic
 {
  public:
-  NewickTree() { 
-    precision_ = 6; 
-    output_buffer_.exceptions(std::ios::failbit); 
-  }
-
-  NewickTree(size_t precision) { 
+  NewickTree() : NewickTree(6, true) { }
+  NewickTree(size_t precision) : NewickTree(precision, true) { }
+  NewickTree(size_t precision, bool has_recombination) { 
     precision_ = precision; 
-    output_buffer_.exceptions(std::ios::failbit); 
+    has_rec_ = has_recombination;
   }
 
   ~NewickTree() {}
@@ -60,21 +57,21 @@ class NewickTree : public SummaryStatistic
   void calculate(const Forest &forest);
   void printLocusOutput(std::ostream &output) const;
 
-  NewickTree* clone() const { return new NewickTree(); };
+  NewickTree* clone() const { return new NewickTree(precision_, has_rec_); };
 
   void clear() {
-    output_buffer_.str("");
     output_buffer_.clear();
+    segment_length_.clear();
     buffer_.clear();
   }
-
-  std::string getTrees() const { return output_buffer_.str(); }
 
  private:
   std::string generateTree(Node *node, const Forest &forest,
                            const bool use_buffer = true);
-  std::stringstream output_buffer_;
+  std::list<std::string> output_buffer_;
+  std::vector<double> segment_length_;
   size_t precision_;
+  bool has_rec_;
 
   /**
    * A map to buffer already created subtrees indexed by their 

--- a/src/summary_statistics/newick_tree.h
+++ b/src/summary_statistics/newick_tree.h
@@ -46,10 +46,12 @@ class NewickTree : public SummaryStatistic
  public:
    NewickTree() { 
     precision_ = 6; 
+    output_buffer_.exceptions(std::ios::failbit); 
    }
 
    NewickTree(size_t precision) { 
     precision_ = precision; 
+    output_buffer_.exceptions(std::ios::failbit); 
    }
 
    ~NewickTree() {}
@@ -71,7 +73,7 @@ class NewickTree : public SummaryStatistic
  private:
    std::string generateTree(Node *node, const Forest &forest,
                             const bool use_buffer = true);
-   std::ostringstream output_buffer_;
+   std::stringstream output_buffer_;
    size_t precision_;
 
    /**

--- a/src/summary_statistics/newick_tree.h
+++ b/src/summary_statistics/newick_tree.h
@@ -44,43 +44,43 @@ struct NewickBuffer {
 class NewickTree : public SummaryStatistic
 {
  public:
-   NewickTree() { 
+  NewickTree() { 
     precision_ = 6; 
     output_buffer_.exceptions(std::ios::failbit); 
-   }
+  }
 
-   NewickTree(size_t precision) { 
+  NewickTree(size_t precision) { 
     precision_ = precision; 
     output_buffer_.exceptions(std::ios::failbit); 
-   }
+  }
 
-   ~NewickTree() {}
+  ~NewickTree() {}
 
-   //Virtual methods
-   void calculate(const Forest &forest);
-   void printLocusOutput(std::ostream &output) const;
+  //Virtual methods
+  void calculate(const Forest &forest);
+  void printLocusOutput(std::ostream &output) const;
 
-   NewickTree* clone() const { return new NewickTree(); };
+  NewickTree* clone() const { return new NewickTree(); };
 
-   void clear() {
-     output_buffer_.str("");
-     output_buffer_.clear();
-     buffer_.clear();
-   }
+  void clear() {
+    output_buffer_.str("");
+    output_buffer_.clear();
+    buffer_.clear();
+  }
 
-   std::string getTrees() const { return output_buffer_.str(); }
+  std::string getTrees() const { return output_buffer_.str(); }
 
  private:
-   std::string generateTree(Node *node, const Forest &forest,
-                            const bool use_buffer = true);
-   std::stringstream output_buffer_;
-   size_t precision_;
+  std::string generateTree(Node *node, const Forest &forest,
+                           const bool use_buffer = true);
+  std::stringstream output_buffer_;
+  size_t precision_;
 
-   /**
-    * A map to buffer already created subtrees indexed by their 
-    * root.
-    */
-   std::map<Node const*, NewickBuffer> buffer_;
+  /**
+   * A map to buffer already created subtrees indexed by their 
+   * root.
+   */
+  std::map<Node const*, NewickBuffer> buffer_;
 };
 
 #endif

--- a/src/summary_statistics/oriented_forest.cc
+++ b/src/summary_statistics/oriented_forest.cc
@@ -49,7 +49,7 @@ void OrientedForest::calculate(const Forest &forest) {
 }
 
 void OrientedForest::printLocusOutput(std::ostream &output) const {
-  output << output_buffer_.str();  
+  output << output_buffer_.rdbuf();  
 }
 
 void OrientedForest::generateTreeData(Node const* node, size_t &pos, int parent_pos) {

--- a/src/summary_statistics/oriented_forest.h
+++ b/src/summary_statistics/oriented_forest.h
@@ -33,38 +33,38 @@
 class OrientedForest : public SummaryStatistic
 {
  public:
-   OrientedForest(const size_t sample_size, const size_t precision) {
+  OrientedForest(const size_t sample_size, const size_t precision) {
     parents_ = std::vector<int>(2*sample_size-1, 0);
     heights_ = std::vector<double>(2*sample_size-1, 0.0);
     output_buffer_.exceptions(std::ios::failbit); 
     output_buffer_.precision(precision);
-   }
+  }
 
-   //Virtual methods
-   void calculate(const Forest &forest);
-   void printLocusOutput(std::ostream &output) const;
-   void clear() {
-     output_buffer_.str("");
-     output_buffer_.clear();
-   }
+  //Virtual methods
+  void calculate(const Forest &forest);
+  void printLocusOutput(std::ostream &output) const;
+  void clear() {
+    output_buffer_.str("");
+    output_buffer_.clear();
+  }
 
-   OrientedForest* clone() const {
-     return new OrientedForest(this->parents_.size(), this->output_buffer_.precision());
-   }
+  OrientedForest* clone() const {
+    return new OrientedForest(this->parents_.size(), this->output_buffer_.precision());
+  }
 
-   std::string getTrees() const { return output_buffer_.str(); }
+  std::string getTrees() const { return output_buffer_.str(); }
 
 #ifdef UNITTEST
-   friend class TestSummaryStatistics;
+  friend class TestSummaryStatistics;
 #endif
 
  private:
-   OrientedForest() {}
-   void generateTreeData(Node const* node, size_t &pos, int parent_pos);
+  OrientedForest() {}
+  void generateTreeData(Node const* node, size_t &pos, int parent_pos);
 
-   std::vector<int> parents_;
-   std::vector<double> heights_;
-   std::stringstream output_buffer_;
+  std::vector<int> parents_;
+  std::vector<double> heights_;
+  std::stringstream output_buffer_;
 };
 
 #endif

--- a/src/summary_statistics/oriented_forest.h
+++ b/src/summary_statistics/oriented_forest.h
@@ -33,6 +33,7 @@
 class OrientedForest : public SummaryStatistic
 {
  public:
+  OrientedForest(const size_t sample_size) : OrientedForest(sample_size, 6) { }
   OrientedForest(const size_t sample_size, const size_t precision) {
     parents_ = std::vector<int>(2*sample_size-1, 0);
     heights_ = std::vector<double>(2*sample_size-1, 0.0);

--- a/src/summary_statistics/oriented_forest.h
+++ b/src/summary_statistics/oriented_forest.h
@@ -33,11 +33,12 @@
 class OrientedForest : public SummaryStatistic
 {
  public:
-   OrientedForest(const size_t sample_size) {
+   OrientedForest(const size_t sample_size, const size_t precision) {
     parents_ = std::vector<int>(2*sample_size-1, 0);
     heights_ = std::vector<double>(2*sample_size-1, 0.0);
+    output_buffer_.exceptions(std::ios::failbit); 
+    output_buffer_.precision(precision);
    }
-   ~OrientedForest() {}
 
    //Virtual methods
    void calculate(const Forest &forest);
@@ -48,7 +49,7 @@ class OrientedForest : public SummaryStatistic
    }
 
    OrientedForest* clone() const {
-     return new OrientedForest(this->parents_.size());
+     return new OrientedForest(this->parents_.size(), this->output_buffer_.precision());
    }
 
    std::string getTrees() const { return output_buffer_.str(); }
@@ -63,7 +64,7 @@ class OrientedForest : public SummaryStatistic
 
    std::vector<int> parents_;
    std::vector<double> heights_;
-   std::ostringstream output_buffer_;
+   std::stringstream output_buffer_;
 };
 
 #endif

--- a/tests/unittests/test_model.cc
+++ b/tests/unittests/test_model.cc
@@ -436,18 +436,23 @@ class TestModel : public CppUnit::TestCase {
 
   void testSetGetRecombinationRate() {
     Model model = Model();
+    CPPUNIT_ASSERT( !model.has_recombination() );
+
     model.setLocusLength(101);
     model.setRecombinationRate(0.001);
     CPPUNIT_ASSERT_EQUAL( 0.001, model.recombination_rate() );
     CPPUNIT_ASSERT_EQUAL( (size_t)101, model.loci_length() );
+    CPPUNIT_ASSERT( model.has_recombination() );
 
     model.setRecombinationRate(0.001, false, false);
     CPPUNIT_ASSERT_EQUAL( 0.001, model.recombination_rate() );
     CPPUNIT_ASSERT_EQUAL( (size_t)101, model.loci_length() );
+    CPPUNIT_ASSERT( model.has_recombination() );
 
     model.setRecombinationRate(0.001, true, false);
     CPPUNIT_ASSERT_EQUAL( 0.00001, model.recombination_rate() );
     CPPUNIT_ASSERT_EQUAL( (size_t)101, model.loci_length() );
+    CPPUNIT_ASSERT( model.has_recombination() );
 
     model.setRecombinationRate(0.001, false, true);
     CPPUNIT_ASSERT_EQUAL( 0.001/(4*model.default_pop_size), model.recombination_rate() );
@@ -518,7 +523,6 @@ class TestModel : public CppUnit::TestCase {
     CPPUNIT_ASSERT( areSame( n_2*std::exp(-2), model.population_size(1) ) );
     CPPUNIT_ASSERT( areSame( n_1*std::exp(-2*2), model.population_size(0, 4.5) ) );
     CPPUNIT_ASSERT( areSame( n_2*std::exp(-2*2), model.population_size(1, 4.5) ) );
-    model.reset();
     
     // Growth with a pop size change in between
     model = Model(5); 
@@ -579,7 +583,6 @@ class TestModel : public CppUnit::TestCase {
     CPPUNIT_ASSERT( areSame( size0, model.population_size(0) ) );
     CPPUNIT_ASSERT( areSame( size1, model.population_size(1) ) );
 
-    model.reset();
     model = Model(5); 
     model.set_population_number(2);
     model.addSymmetricMigration(0, 1.0);

--- a/tests/unittests/test_summary_statistics.cc
+++ b/tests/unittests/test_summary_statistics.cc
@@ -265,8 +265,7 @@ class TestSummaryStatistics : public CppUnit::TestCase {
       CPPUNIT_ASSERT( of.heights_.at(5) == 3.0 );
     } else {
       CPPUNIT_ASSERT( of.parents_.at(0) == 6 );
-      CPPUNIT_ASSERT( of.parents_.at(1) == 6 );
-      CPPUNIT_ASSERT( of.parents_.at(2) == 5 );
+      CPPUNIT_ASSERT( of.parents_.at(1) == 6 ); CPPUNIT_ASSERT( of.parents_.at(2) == 5 );
       CPPUNIT_ASSERT( of.parents_.at(3) == 5 );
       CPPUNIT_ASSERT( of.heights_.at(5) == 1.0 );
     }
@@ -301,7 +300,7 @@ class TestSummaryStatistics : public CppUnit::TestCase {
     forest->set_current_base(0.0);
     forest->set_next_base(10.0);
     
-    NewickTree of(4);
+    NewickTree of(4, forest->model().has_recombination());
     std::ostringstream output;
     of.calculate(*forest);
     of.printLocusOutput(output);
@@ -310,8 +309,8 @@ class TestSummaryStatistics : public CppUnit::TestCase {
     
     output.str("");
     output.clear();
-    of.clear();
     forest->writable_model()->setRecombinationRate(0.0001);
+    of = NewickTree(4, forest->model().has_recombination());
     of.calculate(*forest);
     of.printLocusOutput(output);
     //std::cout << output.str() << std::endl;


### PR DESCRIPTION
* save each tree in a separate string
* adds error messages for stringstreams

fixes #76