### PR TITLE
change column names of transposed segsites

### DIFF
--- a/src/summary_statistics/seg_sites.cc
+++ b/src/summary_statistics/seg_sites.cc
@@ -50,7 +50,7 @@ void SegSites::printLocusOutput(std::ostream &output) const {
   if ( transpose_ ) {
     output << "transposed segsites: " << countMutations() << std::endl;
     if ( countMutations() == 0 ) return;
-    output << "positions height";
+    output << "position time";
     for (size_t i = 0; i < haplotypes_.at(0).size(); i++){
       output << " " << i+1;
     }


### PR DESCRIPTION
@shajoezhu I'd like to change the column labels for the transposed seg. sites from `positions` and `height` to `position` and `time` to make to more clear what is printed and more consistent. What's your opinion here?