### PR TITLE
Fix #102

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,20 @@
 scrm Version History
 ========================
 
+scrm 1.7.1
+------------------------
+Released: 2016-03-23
+
+### Bug Fixes
++ Fixes that bug that could lead to false results when the "-eI" option
+  was used to include non-contemporary samples. In that case, scrm
+  could skip the time interval between the MRCA of the contemporary samples
+  and the time of the "-eI" event (if any), and neglect all events 
+  during that time. We recommend to repeat all simulations which
+  used "-eI" with the updated version (#102).
+
+
+
 scrm 1.7.0
 ------------------------
 Released: 2016-02-07

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([scrm], [1.7.0],[https://github.com/paulstaab/scrm/issues])
+AC_INIT([scrm], [1.7.1],[https://github.com/paulstaab/scrm/issues])
 AM_INIT_AUTOMAKE([subdir-objects -Wall -Werror foreign])
 
 # Use -O3 as default optimization level

--- a/src/forest.cc
+++ b/src/forest.cc
@@ -474,20 +474,21 @@ void Forest::sampleCoalescences(Node *start_node) {
   assert( start_node->is_root() );
   // We can have one or active local nodes: If the coalescing node passes the
   // local root, it also starts a coalescence.
-  set_active_node(0, start_node);
-  set_active_node(1, this->local_root());
+  if (start_node->height() > this->local_root()->height()) {
+    set_active_node(0, this->local_root());
+    set_active_node(1, start_node);
+  } else {
+    set_active_node(0, start_node);
+    set_active_node(1, this->local_root());
+  }
+  assert ( active_node(0)->height() <= active_node(1)->height() );
 
   // Initialize Temporary Variables
-  tmp_event_ = Event(start_node->height());
+  tmp_event_ = Event(active_node(0)->height());
   coalescence_finished_ = false;
 
-  // This assertion needs an exception for building the initial tree
-  assert ( current_rec() == 1 ||
-           active_node(1)->in_sample() ||
-           start_node->height() <= active_node(1)->height() );
-
   // Only prune every second round
-  for (TimeIntervalIterator ti(this, start_node); ti.good(); ++ti) {
+  for (TimeIntervalIterator ti(this, active_node(0)); ti.good(); ++ti) {
 
     dout << "* * Time interval: " << (*ti).start_height() << " - "
          << (*ti).end_height() << " (Last event at " << tmp_event_.time() << ")" << std::endl;

--- a/tests/test_binaries.sh
+++ b/tests/test_binaries.sh
@@ -88,5 +88,6 @@ echo ""
 echo "Various Edge Cases"
  test_scrm 6 1 -I 2 3 3 0.5 -r 1 100 -es 0 2 0.5 -ej 1 3 1 -t 1  || exit 1
  test_scrm 10 1 -es 1.0 1 0.5 -ej 1.0 2 1 || exit 1
+ test_scrm 4 1 -t 1.0 -I 2 2 0 -ej 1.0 1 2 -eI 3.5 0 2
 echo ""
 

--- a/tests/unittests/test_forest.cc
+++ b/tests/unittests/test_forest.cc
@@ -1,4 +1,3 @@
-#include <cppunit/TestCase.h>
 #include <cppunit/extensions/HelperMacros.h>
 
 #include "../../src/forest.h"
@@ -19,6 +18,7 @@ class TestForest : public CppUnit::TestCase {
   CPPUNIT_TEST( testSamplePoint );
   CPPUNIT_TEST( testCalcRecombinationRate );
   CPPUNIT_TEST( testCalcRate );
+  CPPUNIT_TEST( testCalcRateWithArachicSamples );
   CPPUNIT_TEST( testNodeIsOld );
   CPPUNIT_TEST( testPrune );
   CPPUNIT_TEST( testSelectFirstTime );
@@ -175,6 +175,23 @@ class TestForest : public CppUnit::TestCase {
 
     delete node1;
     delete node2;
+  }
+
+  void testCalcRateWithArachicSamples() {
+    Node* node1 = forest->nodes()->createNode(20, 5);
+    forest->nodes()->add(node1);
+    TimeIntervalIterator tii(forest, node1);
+    double pop_size = 2*forest->model().population_size(0);
+
+    forest->set_active_node(0, node1);
+    forest->set_active_node(1, forest->local_root());
+    forest->states_[0] = 1;
+    forest->states_[1] = 1;
+  
+    CPPUNIT_ASSERT_NO_THROW( forest->calcRates(*tii) );
+    CPPUNIT_ASSERT( areSame(1.0/pop_size, forest->rates_[0]) );
+    CPPUNIT_ASSERT_EQUAL( 0.0, forest->rates_[1] );
+    CPPUNIT_ASSERT_EQUAL( 0.0, forest->rates_[2] );
   }
 
   void testGetNodeState() {


### PR DESCRIPTION
Fixes that bug that could lead to false results when the "-eI" option was used to include non-contemporary samples. In that case, scrm could skip the time interval between the MRCA of the contemporary samples and the time of the "-eI" event (if any), and neglect all events  during that time. We recommend to repeat all simulations which used "-eI" with the updated version (#102).