### PR TITLE
Improve memory safety

### DIFF
--- a/src/node_container.h
+++ b/src/node_container.h
@@ -83,8 +83,9 @@ class NodeContainer {
         node_lanes_.push_back(new_lane);
       }
     }
-    (*node_lanes_.at(lane_counter_))[node_counter_] = Node(height, label);
-    return &*(node_lanes_[lane_counter_]->begin() + node_counter_++);
+    ++node_counter_;
+    node_lanes_.at(lane_counter_)->push_back(Node(height, label));
+    return &*(node_lanes_.at(lane_counter_)->end() - 1);
   }
 
   // Create Nodes
@@ -107,8 +108,9 @@ class NodeContainer {
         node_lanes_.push_back(new_lane);
       }
     }
-    (*node_lanes_.at(lane_counter_))[node_counter_] = Node(copiedNode);
-    return &*(node_lanes_[lane_counter_]->begin() + node_counter_++);
+    ++node_counter_;
+    node_lanes_.at(lane_counter_)->push_back(copiedNode);
+    return &*(node_lanes_.at(lane_counter_)->end() - 1);
   }
 
   void push_back(Node* node);

--- a/tests/algorithmtest/test_algorithm.cc
+++ b/tests/algorithmtest/test_algorithm.cc
@@ -41,9 +41,9 @@ class TestAlgorithm : public CppUnit::TestCase {
     
     std::cout << "." << std::flush;
 
-    Forest forest = Forest(&model, this->rg);
     for (size_t i = 0; i < replicates; ++i) {
       // Check initial tree
+      Forest forest = Forest(&model, this->rg);
       forest.buildInitialTree();
       tmrca[0] += forest.getTMRCA(true);
       tree_length[0] += forest.getLocalTreeLength(true);
@@ -58,9 +58,6 @@ class TestAlgorithm : public CppUnit::TestCase {
           tree_length[j] += forest.getLocalTreeLength(true);
         }
       }
-
-      // Clear Forest
-      forest.clear();
     }
 
     // Allow an relative error of 2.5%. It would be nice to calculate


### PR DESCRIPTION
Use less evil memory access patterns in NodeContainer to prevent clang address saniters warnings found on CRAN:

```
> sum_stats <- scrm('5 1 -r 3.1 100 -t 1.5 -T -L')
=================================================================
==23995==ERROR: AddressSanitizer: container-overflow on address 0x7f5240e9f800 at pc 0x0000004ec48c bp 0x7ffed2936810 sp 0x7ffed2935fc0
WRITE of size 104 at 0x7f5240e9f800 thread T0
    #0 0x4ec48b in __asan_memcpy /data/gannet/ripley/Sources/LLVM/6.0.x/trunk/projects/compiler-rt/lib/asan/asan_interceptors_memintrinsics.cc:23
    #1 0x7f524149e0c1 in NodeContainer::createNode(double, unsigned long) /data/gannet/ripley/R/packages/tests-clang-SAN/scrm/src/scrm/node_container.h:86:53
```