### PR TITLE
Fix 'catching polymorphic type ‘class std::invalid_argument’ by value' warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,7 @@ AX_CHECK_COMPILE_FLAG([-Wcast-align], [OPT_CXXFLAGS="$OPT_CXXFLAGS -Wcast-align"
 AX_CHECK_COMPILE_FLAG([-Wunused], [OPT_CXXFLAGS="$OPT_CXXFLAGS -Wunused"], [], [-Werror])
 AX_CHECK_COMPILE_FLAG([-Woverloaded-virtual], [OPT_CXXFLAGS="$OPT_CXXFLAGS -Woverloaded-virtual"], [], [-Werror])
 AX_CHECK_COMPILE_FLAG([-pedantic], [OPT_CXXFLAGS="$OPT_CXXFLAGS -pedantic"], [], [-Werror])
+AX_CHECK_COMPILE_FLAG([-Wcatch-value], [OPT_CXXFLAGS="$OPT_CXXFLAGS -Wcatch-value"], [], [-Werror])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/src/param.cc
+++ b/src/param.cc
@@ -132,7 +132,7 @@ Model Param::parse() {
       // there might or might not follow a symmetric migration rate
       try {
         model.addSymmetricMigration(0.0, readNextInput<double>()/(model.population_number()-1), true, true);
-      } catch (std::invalid_argument e) {
+      } catch (std::invalid_argument& e) {
         --argv_i;
       }
     }
@@ -382,7 +382,7 @@ Model Param::parse() {
       try {
         // Maybe read in up to 3 seeds (ms compatibility)
         for (size_t i = 1; i < 3; ++i) seeds.at(i) = readNextInt();
-      } catch (std::invalid_argument e) {
+      } catch (std::invalid_argument& e) {
         --argv_i;
       }
 


### PR DESCRIPTION
which will be issued by gcc8 once we start using it (in a few years...)