### PR TITLE
Add support to ppc64le focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,20 @@ matrix:
   exclude:
     - os: osx
       env: CXXFLAGS="-m32 -Werror"
+
+# Power jobs
+  include:
+    - os: linux
+      arch: ppc64le
+      dist: focal
+      compiler: gcc
+      env: CXXFLAGS="-Werror"
+    - os: linux
+      arch: ppc64le
+      dist: focal
+      compiler: clang
+      env: CXXFLAGS="-Werror"
+      
 dist: bionic
 before_install: .travis/setup.sh "$TRAVIS_OS_NAME" "$CXX" "$CXXFLAGS"
 before_script:


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date. 
Since 32 bit not supported for powe little endian, omitted those jobs